### PR TITLE
Remove next/font from layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,6 @@
 // app/layout.tsx
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
 import './globals.css'
-
-const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'ProbFixer - Find Trusted Artisans in Nigeria',
@@ -18,7 +15,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- stop using `next/font` in `layout.tsx`

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6872d26f380483298935d6d2aaee7686