### PR TITLE
Add vibrant color scheme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,25 +9,25 @@
 @layer base {
   :root {
     /* Brand colors */
-    --primary: 217 91% 60%;
+    --primary: 265 80% 60%;
     --primary-foreground: 0 0% 100%;
-    --primary-dark: 217 91% 45%;
-    --primary-light: 217 91% 95%;
-    --secondary: 25 95% 53%;
+    --primary-dark: 265 80% 50%;
+    --primary-light: 265 80% 95%;
+    --secondary: 330 81% 60%;
     --secondary-foreground: 0 0% 100%;
-    --secondary-dark: 25 95% 43%;
-    --accent: 142 76% 36%;
+    --secondary-dark: 330 81% 50%;
+    --accent: 204 94% 58%;
     --accent-foreground: 0 0% 100%;
-    --accent-light: 142 76% 93%;
+    --accent-light: 204 94% 93%;
     --background: 0 0% 100%;
     --foreground: 224 71% 4%;
     --muted: 220 14% 96%;
     --muted-foreground: 220 9% 46%;
     --border: 220 13% 91%;
-    --success: 142 76% 36%;
-    --warning: 38 92% 50%;
+    --success: 152 64% 44%;
+    --warning: 48 94% 53%;
     --error: 0 84% 60%;
-    --info: 217 91% 60%;
+    --info: 198 94% 48%;
     --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
     --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
     --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
@@ -46,8 +46,8 @@
 
   /* Dark-mode overrides */
   .dark {
-    --primary-dark: 217 91% 70%;
-    --primary-light: 217 91% 15%;
+    --primary-dark: 265 80% 70%;
+    --primary-light: 265 80% 30%;
     --background: 224 71% 4%;
     --foreground: 210 40% 98%;
     --muted: 217 33% 17%;

--- a/components/home/FeaturedArtisans.tsx
+++ b/components/home/FeaturedArtisans.tsx
@@ -88,7 +88,7 @@ const FeaturedArtisans = () => {
                   <h3 className="font-semibold text-lg">{artisan.name}</h3>
                   <p className="text-sm text-gray-600">{artisan.service}</p>
                   {artisan.verified && (
-                    <span className="inline-flex items-center text-xs text-primary-600 mt-1">
+                    <span className="inline-flex items-center text-xs text-purple-600 mt-1">
                       ✓ Verified
                     </span>
                   )}

--- a/components/home/Hero.tsx
+++ b/components/home/Hero.tsx
@@ -19,12 +19,12 @@ const Hero = () => {
   ]
 
   return (
-    <section className="bg-gradient-to-br from-primary-50 to-white py-16 md:py-24">
+    <section className="bg-gradient-to-br from-purple-50 via-pink-50 to-white py-16 md:py-24">
       <div className="container mx-auto px-4">
         <div className="max-w-4xl mx-auto text-center">
           <h1 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6">
             Find Trusted Artisans in{' '}
-            <span className="text-primary-600">Minutes</span>
+            <span className="text-purple-600">Minutes</span>
           </h1>
           <p className="text-xl text-gray-600 mb-8">
             Connect with verified professionals for all your home and office repairs

--- a/components/home/HowItWorks.tsx
+++ b/components/home/HowItWorks.tsx
@@ -34,8 +34,8 @@ const HowItWorks = () => {
         <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
           {steps.map((step, index) => (
             <div key={index} className="text-center">
-              <div className="w-16 h-16 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <step.icon className="w-8 h-8 text-primary-600" />
+              <div className="w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <step.icon className="w-8 h-8 text-purple-600" />
               </div>
               <h3 className="text-xl font-semibold mb-2">{step.title}</h3>
               <p className="text-gray-600">{step.description}</p>

--- a/components/home/PopularServices.tsx
+++ b/components/home/PopularServices.tsx
@@ -35,7 +35,7 @@ const PopularServices = () => {
               className="bg-white rounded-xl p-6 hover:shadow-md transition-shadow text-center group"
             >
               <div className="text-4xl mb-3">{service.icon}</div>
-              <h3 className="font-semibold text-gray-900 group-hover:text-primary-600 transition-colors">
+              <h3 className="font-semibold text-gray-900 group-hover:text-purple-600 transition-colors">
                 {service.name}
               </h3>
               <p className="text-sm text-gray-500 mt-1">

--- a/components/home/TrustSection.tsx
+++ b/components/home/TrustSection.tsx
@@ -38,7 +38,7 @@ const TrustSection = () => {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-16">
           {stats.map((stat, index) => (
             <div key={index} className="text-center">
-              <div className="text-3xl md:text-4xl font-bold text-primary-600 mb-2">
+              <div className="text-3xl md:text-4xl font-bold text-purple-600 mb-2">
                 {stat.number}
               </div>
               <div className="text-gray-600">{stat.label}</div>
@@ -59,8 +59,8 @@ const TrustSection = () => {
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
           {features.map((feature, index) => (
             <div key={index} className="text-center">
-              <div className="w-12 h-12 bg-primary-100 rounded-lg flex items-center justify-center mx-auto mb-4">
-                <feature.icon className="w-6 h-6 text-primary-600" />
+              <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4">
+                <feature.icon className="w-6 h-6 text-purple-600" />
                              </div>
               <h3 className="font-semibold text-lg mb-2">{feature.title}</h3>
               <p className="text-gray-600 text-sm">{feature.description}</p>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
           {/* Company Info */}
           <div>
             <div className="flex items-center space-x-2 mb-4">
-              <div className="w-8 h-8 bg-primary-600 rounded-lg flex items-center justify-center">
+              <div className="w-8 h-8 bg-purple-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-xl">P</span>
               </div>
               <span className="font-bold text-xl">ProbFixer</span>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -13,7 +13,7 @@ const Header = () => {
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <Link href="/" className="flex items-center space-x-2">
-            <div className="w-8 h-8 bg-primary-600 rounded-lg flex items-center justify-center">
+            <div className="w-8 h-8 bg-purple-600 rounded-lg flex items-center justify-center">
               <span className="text-white font-bold text-xl">P</span>
             </div>
             <span className="font-bold text-xl">ProbFixer</span>
@@ -21,13 +21,13 @@ const Header = () => {
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex items-center space-x-8">
-            <Link href="/browse" className="text-gray-700 hover:text-primary-600 transition-colors">
+            <Link href="/browse" className="text-gray-700 hover:text-purple-600 transition-colors">
               Find Artisans
             </Link>
-            <Link href="/how-it-works" className="text-gray-700 hover:text-primary-600 transition-colors">
+            <Link href="/how-it-works" className="text-gray-700 hover:text-purple-600 transition-colors">
               How it Works
             </Link>
-            <Link href="/post-problem" className="text-gray-700 hover:text-primary-600 transition-colors">
+            <Link href="/post-problem" className="text-gray-700 hover:text-purple-600 transition-colors">
               Post a Job
             </Link>
           </nav>
@@ -56,13 +56,13 @@ const Header = () => {
         {isMenuOpen && (
           <div className="md:hidden py-4 border-t">
             <nav className="flex flex-col space-y-4">
-              <Link href="/browse" className="text-gray-700 hover:text-primary-600">
+              <Link href="/browse" className="text-gray-700 hover:text-purple-600">
                 Find Artisans
               </Link>
-              <Link href="/how-it-works" className="text-gray-700 hover:text-primary-600">
+              <Link href="/how-it-works" className="text-gray-700 hover:text-purple-600">
                 How it Works
               </Link>
-              <Link href="/post-problem" className="text-gray-700 hover:text-primary-600">
+              <Link href="/post-problem" className="text-gray-700 hover:text-purple-600">
                 Post a Job
               </Link>
               <hr className="my-2" />

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -8,7 +8,7 @@ export interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
 const Badge = forwardRef<HTMLDivElement, BadgeProps>(
   ({ className, variant = 'default', ...props }, ref) => {
     const variants = {
-      default: 'border-transparent bg-primary-600 text-white',
+      default: 'border-transparent bg-purple-600 text-white',
       secondary: 'border-transparent bg-gray-100 text-gray-900',
       destructive: 'border-transparent bg-red-500 text-white',
       outline: 'text-gray-950'
@@ -18,7 +18,7 @@ const Badge = forwardRef<HTMLDivElement, BadgeProps>(
       <div
         ref={ref}
         className={cn(
-          "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2",
+          "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2",
           variants[variant],
           className
         )}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -16,7 +16,7 @@ const Button: FC<ButtonProps> = ({
   const baseStyles = 'inline-flex items-center justify-center rounded-lg font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50'
   
   const variants = {
-    primary: 'bg-primary-600 text-white hover:bg-primary-700 focus-visible:ring-primary-600',
+    primary: 'bg-purple-600 text-white hover:bg-purple-700 focus-visible:ring-purple-600',
     secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200 focus-visible:ring-gray-400',
     outline: 'border border-gray-300 bg-transparent hover:bg-gray-100 focus-visible:ring-gray-400',
     ghost: 'hover:bg-gray-100 hover:text-gray-900 focus-visible:ring-gray-400'

--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -9,7 +9,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -11,7 +11,7 @@ const Select = forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <select
         className={cn(
-          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- modernize base color variables
- update hero section gradient and heading color
- refresh primary color references across components

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6872d6c1868c8329be594d93062d7e73